### PR TITLE
Use lexical for number parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+# Changes
+- Increase `Number` `FromStr` performance.
+
 # 0.4.0
 - Add `Borrow` trait to `Kstr`
 - Added the container `Accessor` API

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,10 @@ categories = [ "data-structures", "encoding", "parsing" ]
 license = "MIT"
 
 [dependencies]
-base91 =    { version = "0.0.1",    optional = true,	default-features = false }
-nom =	    { version = "5",	    optional = true,	default-features = false,   features = [ "std", "lexical" ] }
-serde =	    { version = "1",	    optional = true, 	default-features = false,   features = [ "std" ] }
+base91 =       { version = "0.0.1", optional = true,	default-features = false }
+lexical-core = { version = "0.7",   optional = false,	default-features = false,   features = [ "format" ] }
+nom =	       { version = "5",	    optional = true,	default-features = false,   features = [ "std", "lexical" ] }
+serde =	       { version = "1",	    optional = true, 	default-features = false,   features = [ "std" ] }
 
 [features]
 default =   [ "encode", "format", "parse", ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 
 [dependencies]
 base91 =       { version = "0.0.1", optional = true,	default-features = false }
-lexical-core = { version = "0.7",   optional = false,	default-features = false,   features = [ "format" ] }
+lexical-core = { version = "0.7",   optional = false,	default-features = false,   features = [ "std", "format" ] }
 nom =	       { version = "5",	    optional = true,	default-features = false,   features = [ "std", "lexical" ] }
 serde =	       { version = "1",	    optional = true, 	default-features = false,   features = [ "std" ] }
 

--- a/src/ds/num.rs
+++ b/src/ds/num.rs
@@ -210,20 +210,23 @@ impl fmt::Display for Number {
 impl FromStr for Number {
     type Err = IntoNumberErr;
     fn from_str(s: &str) -> Result<Self, IntoNumberErr> {
+        use ::lexical_core::parse_format;
         if s.is_empty() {
             return Err(IntoNumberErr);
         }
-        let neg = s.starts_with('-');
-        let int = parse_uint(if neg { &s[1..] } else { s });
-        match int {
-            Ok(x) if neg => match x.cmp(&170_141_183_460_469_231_731_687_303_715_884_105_728) {
-                Ordering::Greater => Err(IntoNumberErr),
-                Ordering::Equal => Ok(Int(std::i128::MIN)),
-                Ordering::Less => Ok(Int(-(x as i128))),
-            },
-            Ok(x) => Ok(Uint(x)),
-            Err(_) => s.parse::<f64>().map(Float).map_err(|_| IntoNumberErr),
-        }
+
+            let fmt = ::lexical_core::NumberFormat::OCAML_STRING;
+            let bytes = s.as_bytes();
+            let neg = bytes[0] == b'-';
+            let valid_int = bytes.iter().skip(if neg { 1 } else { 0 }).all(|b| b.is_ascii_digit() || *b == b'_');
+            
+            if !valid_int {
+                s.parse::<f64>().map(Float).map_err(|_| IntoNumberErr)
+            } else if neg {
+                parse_format::<i128>(bytes, fmt).map(Int).map_err(|_| IntoNumberErr)
+            } else {
+                parse_format::<u128>(bytes, fmt).map(Uint).map_err(|_| IntoNumberErr)
+            }
     }
 }
 
@@ -231,18 +234,6 @@ impl Hash for Number {
     fn hash<H: Hasher>(&self, hasher: &mut H) {
         self.as_f64().to_bits().hash(hasher)
     }
-}
-
-fn parse_uint(s: &str) -> Result<u128, IntoNumberErr> {
-    let mut n: u128 = 0;
-    for ch in s.chars() {
-        if ch == '_' {
-            continue;
-        }
-        let i = ch.to_digit(10).ok_or(IntoNumberErr)? as u128;
-        n = n * 10 + i;
-    }
-    Ok(n)
 }
 
 #[derive(PartialEq)]

--- a/src/ds/num.rs
+++ b/src/ds/num.rs
@@ -215,18 +215,25 @@ impl FromStr for Number {
             return Err(IntoNumberErr);
         }
 
-            let fmt = ::lexical_core::NumberFormat::OCAML_STRING;
-            let bytes = s.as_bytes();
-            let neg = bytes[0] == b'-';
-            let valid_int = bytes.iter().skip(if neg { 1 } else { 0 }).all(|b| b.is_ascii_digit() || *b == b'_');
-            
-            if !valid_int {
-                s.parse::<f64>().map(Float).map_err(|_| IntoNumberErr)
-            } else if neg {
-                parse_format::<i128>(bytes, fmt).map(Int).map_err(|_| IntoNumberErr)
-            } else {
-                parse_format::<u128>(bytes, fmt).map(Uint).map_err(|_| IntoNumberErr)
-            }
+        let fmt = ::lexical_core::NumberFormat::OCAML_STRING;
+        let bytes = s.as_bytes();
+        let neg = bytes[0] == b'-';
+        let valid_int = bytes
+            .iter()
+            .skip(if neg { 1 } else { 0 })
+            .all(|b| b.is_ascii_digit() || *b == b'_');
+
+        if !valid_int {
+            s.parse::<f64>().map(Float).map_err(|_| IntoNumberErr)
+        } else if neg {
+            parse_format::<i128>(bytes, fmt)
+                .map(Int)
+                .map_err(|_| IntoNumberErr)
+        } else {
+            parse_format::<u128>(bytes, fmt)
+                .map(Uint)
+                .map_err(|_| IntoNumberErr)
+        }
     }
 }
 

--- a/src/ds/val.rs
+++ b/src/ds/val.rs
@@ -249,10 +249,7 @@ impl<'a> Value<'a> {
     /// assert_eq!(value.unit(), true);
     /// ```
     pub fn unit(&self) -> bool {
-        match &self {
-            Value::Unit => true,
-            _ => false,
-        }
+        matches!(&self, Value::Unit)
     }
 
     /// `Value` is a boolean value.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@
 //! - [ ] further testing of parsing to catch edge cases
 
 #![warn(missing_docs)]
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(broken_intra_doc_links)]
 
 // **************** no-feature ******************
 


### PR DESCRIPTION
Improves `Number` `FromStr` parsing performance by leveraging `lexical-core` for integers, and providing more smarts about which parsing path to take. Importantly it greatly improves error path performance.

Interestingly using `std::f64::parse` was more performant than `lexical-core`'s offering.

### Benchmarks compared to `master`

![image](https://user-images.githubusercontent.com/13831379/97819481-f1437b80-1cfc-11eb-94f5-d665f1ba94e8.png)
